### PR TITLE
chore(github): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/mdn-observatory-webext"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add Dependabot configuration, enabling Dependabot updates for GitHub Actions and npm packages (both in `/` and `/mdn-observatory-webext`).

### Motivation

Consistency with other repos.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

([MP-1348](https://mozilla-hub.atlassian.net/browse/MP-1348))