### PR TITLE
fix(api): error messages

### DIFF
--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -57,20 +57,8 @@ export class InvalidHostNameLookupError extends AppError {
    * @param {string} hostname
    */
   constructor(hostname) {
-    super(`${hostname} can not be resolved`);
+    super(`The host name cannot be resolved`);
     this.name = "invalid-hostname-lookup";
     this.statusCode = STATUS_CODES.unprocessableEntity;
-  }
-}
-
-export class RescanTooSoonError extends AppError {
-  /**
-   *
-   * @param {string} hostname
-   */
-  constructor(hostname) {
-    super(`${hostname} is on temporary cooldown'`);
-    this.name = "rescan-attempt-too-soon";
-    this.statusCode = STATUS_CODES.badRequest;
   }
 }

--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -57,7 +57,7 @@ export class InvalidHostNameLookupError extends AppError {
    * @param {string} hostname
    */
   constructor(hostname) {
-    super(`The host name cannot be resolved`);
+    super(`${hostname} cannot be resolved`);
     this.name = "invalid-hostname-lookup";
     this.statusCode = STATUS_CODES.unprocessableEntity;
   }

--- a/test/apiv2.test.js
+++ b/test/apiv2.test.js
@@ -213,10 +213,7 @@ describeOrSkip("API V2", function () {
     const r = JSON.parse(response.body);
     assert.isObject(r);
     assert.equal(r.error, "invalid-hostname-lookup");
-    assert.equal(
-      r.message,
-      "www.somethingorother1234.mozilla.net can not be resolved"
-    );
+    assert.equal(r.message, "The host name cannot be resolved");
   }).timeout(6000);
 
   it("responds to GET /analyze of an ip address", async function () {

--- a/test/apiv2.test.js
+++ b/test/apiv2.test.js
@@ -213,7 +213,10 @@ describeOrSkip("API V2", function () {
     const r = JSON.parse(response.body);
     assert.isObject(r);
     assert.equal(r.error, "invalid-hostname-lookup");
-    assert.equal(r.message, "The host name cannot be resolved");
+    assert.equal(
+      r.message,
+      "www.somethingorother1234.mozilla.net cannot be resolved"
+    );
   }).timeout(6000);
 
   it("responds to GET /analyze of an ip address", async function () {


### PR DESCRIPTION
### Description

Error message should be generic, this removes host names from the resolver error.

(MP-1397)

### Motivation

These get forwarded to telemetry, so these should be only error classes with no individual information conatined.
