### PR TITLE
fix(scanner): allow 401 and 403 responses, set proper accept header on requests

### DIFF
--- a/src/scanner/index.js
+++ b/src/scanner/index.js
@@ -32,14 +32,11 @@ export async function scan(hostname, options) {
     throw new Error("The site seems to be down.");
   }
 
-  // We allow 401 and 403 status codes
-  if (
-    r.responses.auto.status < 200 ||
-    (r.responses.auto.status >= 400 &&
-      ![401, 403].includes(r.responses.auto.status))
-  ) {
+  // We allow 2xx, 3xx, 401 and 403 status codes
+  const { status } = r.responses.auto;
+  if (status < 200 || (status >= 400 && ![401, 403].includes(status))) {
     throw new Error(
-      `Site did respond with an unexpected HTTP status code ${r.responses.auto.status}.`
+      `Site did respond with an unexpected HTTP status code ${status}.`
     );
   }
 

--- a/src/scanner/index.js
+++ b/src/scanner/index.js
@@ -32,8 +32,15 @@ export async function scan(hostname, options) {
     throw new Error("The site seems to be down.");
   }
 
-  if (r.responses.auto.status < 200 || r.responses.auto.status >= 300) {
-    throw new Error("Site did not respond with a 2xx HTTP status code.");
+  // We allow 401 and 403 status codes
+  if (
+    r.responses.auto.status < 200 ||
+    (r.responses.auto.status >= 400 &&
+      ![401, 403].includes(r.responses.auto.status))
+  ) {
+    throw new Error(
+      `Site did respond with an unexpected HTTP status code ${r.responses.auto.status}.`
+    );
   }
 
   // Run all the tests on the result


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Allow 401 and 403 responses to support sites redirecting to a login page. Also set an accept header of `text/html` et al.

(MP-1438)

### Motivation

Issues #53, #42
