### PR TITLE
fix(ci): check dependabot PR user instead of actor

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Modify the automerge to check on dependabot user instead of actor to prevent force pushes from forks

### Motivation

Make sure automerging only works for dependabot

### Additional details

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1914746

### Related issues and pull requests

(MP-1479)
