### PR TITLE
feat(cli): make scan usable with npx command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "refreshMaterializedViews": "node src/maintenance/index.js",
     "migrate": "node -e 'import(\"./src/database/migrate.js\").then( m => m.migrateDatabase() )'"
   },
+  "bin": {
+    "mdn-http-observatory-scan": "./scan"
+  },
   "type": "module",
   "author": "",
   "license": "MPL-2.0",

--- a/scan
+++ b/scan
@@ -5,4 +5,4 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-node src/cli/index.js scan $1
+node ./src/cli/index.js scan $1


### PR DESCRIPTION
### Description
Add bin to `package.json` to make to be compatible with the `npx` command, enabling users to run the scan tool directly from the command line.

### Motivation
I would like to run [observatory](https://github.com/mdn/mdn-http-observatory) locally or in CI :) 

