### PR TITLE
fix(csp): allow duplicate report-* directives

### DIFF
--- a/scan
+++ b/scan
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -z "$1" ]; then
-  echo "Usage: $0 <hostname>"
-  exit 1
-fi
-
-node src/cli/index.js scan $1

--- a/src/analyzer/cspParser.js
+++ b/src/analyzer/cspParser.js
@@ -8,7 +8,7 @@ const DIRECTIVES_DISALLOWED_IN_META = [
   "sandbox",
 ];
 const ALLOWED_DUPLICATE_KEYS = new Set(["report-uri", "report-to"]);
-export const DUPLICATE_WARNINGS_KEY = "_observatory_duplicate_warnings";
+export const DUPLICATE_WARNINGS_KEY = "_observatory_duplicate_key_warnings";
 
 /**
  * Parse CSP from meta tags, weeding out directives
@@ -28,7 +28,8 @@ export function parseCspMeta(cspList) {
 /**
  * The returned Map has the directive as the key and a Set of sources as the value.
  * If there are allowed duplicates detected, the first one is kept and the rest are discarded,
- * and an entry in the final Map is added with the key "_observatory_warnings" and the value.
+ * and an entry in the final Map is added with the key "_observatory_duplicate_key_warnings"
+ * and the directive's name as the value.
  *
  * @param {string[]} cspList
  * @returns {Map<string, Set<string>>}

--- a/src/analyzer/tests/csp.js
+++ b/src/analyzer/tests/csp.js
@@ -51,7 +51,7 @@ export class CspOutput extends BaseOutput {
     Expectation.CspImplementedWithUnsafeEval,
     Expectation.CspImplementedWithUnsafeInline,
     Expectation.CspImplementedWithInsecureScheme,
-    Expectation.CspImplementedButHasDuplicateDirectives,
+    Expectation.CspImplementedButDuplicateDirectives,
     Expectation.CspHeaderInvalid,
     Expectation.CspNotImplemented,
     Expectation.CspNotImplementedButReportingEnabled,
@@ -306,7 +306,7 @@ export function contentSecurityPolicyTest(
   );
 
   // Check to see if the test passed or failed
-  // Also switch to duplicate report-uri/report-to if needed
+  // If it passed, report any duplicate report-uri/report-to directives
   if (
     [
       expectation,
@@ -317,7 +317,7 @@ export function contentSecurityPolicyTest(
   ) {
     output.pass = true;
     if (csp.has(DUPLICATE_WARNINGS_KEY)) {
-      output.result = Expectation.CspImplementedButHasDuplicateDirectives;
+      output.result = Expectation.CspImplementedButDuplicateDirectives;
     }
   }
 

--- a/src/analyzer/tests/csp.js
+++ b/src/analyzer/tests/csp.js
@@ -4,7 +4,11 @@ import {
 } from "../../headers.js";
 import { Requests, Policy, BaseOutput } from "../../types.js";
 import { Expectation } from "../../types.js";
-import { parseCsp, parseCspMeta } from "../cspParser.js";
+import {
+  DUPLICATE_WARNINGS_KEY,
+  parseCsp,
+  parseCspMeta,
+} from "../cspParser.js";
 import { getHttpHeaders } from "../utils.js";
 
 const DANGEROUSLY_BROAD = new Set([
@@ -47,6 +51,7 @@ export class CspOutput extends BaseOutput {
     Expectation.CspImplementedWithUnsafeEval,
     Expectation.CspImplementedWithUnsafeInline,
     Expectation.CspImplementedWithInsecureScheme,
+    Expectation.CspImplementedButHasDuplicateDirectives,
     Expectation.CspHeaderInvalid,
     Expectation.CspNotImplemented,
     Expectation.CspNotImplementedButReportingEnabled,
@@ -301,6 +306,7 @@ export function contentSecurityPolicyTest(
   );
 
   // Check to see if the test passed or failed
+  // Also switch to duplicate report-uri/report-to if needed
   if (
     [
       expectation,
@@ -310,10 +316,17 @@ export function contentSecurityPolicyTest(
     ].includes(output.result)
   ) {
     output.pass = true;
+    if (csp.has(DUPLICATE_WARNINGS_KEY)) {
+      output.result = Expectation.CspImplementedButHasDuplicateDirectives;
+    }
   }
 
   output.data = {};
   for (const [key, value] of csp) {
+    // filter out the duplicate warnings key from the parsed CSP
+    if (key === DUPLICATE_WARNINGS_KEY) {
+      continue;
+    }
     output.data[key] = [...value].sort();
   }
 

--- a/src/grader/charts.js
+++ b/src/grader/charts.js
@@ -215,10 +215,10 @@ export const SCORE_TABLE = new Map([
     },
   ],
   [
-    Expectation.CspImplementedButHasDuplicateDirectives,
+    Expectation.CspImplementedButDuplicateDirectives,
     {
       description: `<p>
-        Content Security Policy (CSP) implemented but contains duplicate directives.
+        Content Security Policy (CSP) implemented, but contains duplicate directives.
         </p>`,
       modifier: 0,
       recommendation: `<p>Remove duplicate directives from the CSP</p>`,

--- a/src/grader/charts.js
+++ b/src/grader/charts.js
@@ -214,6 +214,16 @@ export const SCORE_TABLE = new Map([
       </p>`,
     },
   ],
+  [
+    Expectation.CspImplementedButHasDuplicateDirectives,
+    {
+      description: `<p>
+        Content Security Policy (CSP) implemented but contains duplicate directives.
+        </p>`,
+      modifier: 0,
+      recommendation: `<p>Remove duplicate directives from the CSP</p>`,
+    },
+  ],
 
   // Cookies
   [

--- a/src/types.js
+++ b/src/types.js
@@ -106,8 +106,8 @@ export const Expectation = {
   CspNotImplemented: "csp-not-implemented",
   CspNotImplementedButReportingEnabled:
     "csp-not-implemented-but-reporting-enabled",
-  CspImplementedButHasDuplicateDirectives:
-    "csp-implemented-but-has-duplicate-directives",
+  CspImplementedButDuplicateDirectives:
+    "csp-implemented-but-duplicate-directives",
 
   // SUBRESOURCE INTEGRITY
 

--- a/src/types.js
+++ b/src/types.js
@@ -106,6 +106,8 @@ export const Expectation = {
   CspNotImplemented: "csp-not-implemented",
   CspNotImplementedButReportingEnabled:
     "csp-not-implemented-but-reporting-enabled",
+  CspImplementedButHasDuplicateDirectives:
+    "csp-implemented-but-has-duplicate-directives",
 
   // SUBRESOURCE INTEGRITY
 

--- a/test/csp-parser.test.js
+++ b/test/csp-parser.test.js
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { DUPLICATE_WARNINGS_KEY, parseCsp } from "../src/analyzer/cspParser.js";
+import { parseCsp } from "../src/analyzer/cspParser.js";
 
 describe("Content Security Policy Parser", function () {
   it("should parse policy correctly", function () {
@@ -210,14 +210,14 @@ describe("Content Security Policy Parser", function () {
     ];
     const res = parseCsp(policy);
     assert(res);
-    assert(res.has(DUPLICATE_WARNINGS_KEY));
-    assert(res.get(DUPLICATE_WARNINGS_KEY)?.has("report-uri"));
+    assert(res.has("_observatory_duplicate_key_warnings"));
+    assert(res.get("_observatory_duplicate_key_warnings")?.has("report-uri"));
   });
   it("should parse a policy with duplicate report-to entries and report those duplicates", function () {
     let policy = ["report-to some_name ; report-to some_other_name"];
     const res = parseCsp(policy);
     assert(res);
-    assert(res.has(DUPLICATE_WARNINGS_KEY));
-    assert(res.get(DUPLICATE_WARNINGS_KEY)?.has("report-to"));
+    assert(res.has("_observatory_duplicate_key_warnings"));
+    assert(res.get("_observatory_duplicate_key_warnings")?.has("report-to"));
   });
 });

--- a/test/csp-parser.test.js
+++ b/test/csp-parser.test.js
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import { parseCsp } from "../src/analyzer/cspParser.js";
+import { DUPLICATE_WARNINGS_KEY, parseCsp } from "../src/analyzer/cspParser.js";
 
 describe("Content Security Policy Parser", function () {
   it("should parse policy correctly", function () {
@@ -196,11 +196,28 @@ describe("Content Security Policy Parser", function () {
     }
   });
 
-  it("should parse this header correctly", function () {
+  it("should parse this example header correctly", function () {
     let policy = [
       "default-src 'self' blob: https://*.cnn.com:* http://*.cnn.com:* *.cnn.io:* *.cnn.net:* *.turner.com:* *.turner.io:* *.ugdturner.com:* courageousstudio.com *.vgtf.net:*; script-src 'unsafe-eval' 'unsafe-inline' 'self' *; style-src 'unsafe-inline' 'self' blob: *; child-src 'self' blob: *; frame-src 'self' *; object-src 'self' *; img-src 'self' data: blob: *; media-src 'self' data: blob: *; font-src 'self' data: *; connect-src 'self' data: *; frame-ancestors 'self' https://*.cnn.com:* http://*.cnn.com https://*.cnn.io:* http://*.cnn.io:* *.turner.com:* courageousstudio.com;",
     ];
     const res = parseCsp(policy);
     assert(res);
+  });
+
+  it("should parse a policy with duplicate report-uri entries and report those duplicates", function () {
+    let policy = [
+      "report-uri https://www.dropbox.com/csp_log?policy_name=metaserver-whitelist ; report-uri https://www.dropbox.com/csp_log?policy_name=metaserver-dynamic",
+    ];
+    const res = parseCsp(policy);
+    assert(res);
+    assert(res.has(DUPLICATE_WARNINGS_KEY));
+    assert(res.get(DUPLICATE_WARNINGS_KEY)?.has("report-uri"));
+  });
+  it("should parse a policy with duplicate report-to entries and report those duplicates", function () {
+    let policy = ["report-to some_name ; report-to some_other_name"];
+    const res = parseCsp(policy);
+    assert(res);
+    assert(res.has(DUPLICATE_WARNINGS_KEY));
+    assert(res.get(DUPLICATE_WARNINGS_KEY)?.has("report-to"));
   });
 });


### PR DESCRIPTION
### Description

If a CSP entry contains duplicate `report-to` or `report-uri` entries, the entry is still considered valid, similar to browser behaviour. Only the first encountered value is taken into account.

(MP-1799)

### Motivation

CSP entries were flagged as invalid because of duplicate `report-uri` values. After discussion with the security team, `report-*` directives were deemed ok to contain duplicates in our scans. Other duplicates are still flagged as invalid as in the original observatory.

### Additional details

There is a new result type `CspImplementedButHasDuplicateDirectives` (0 points) that kicks in when the CSP test generally passes, but duplicate `report-*` directives were detected.

