### PR TITLE
Feat enable docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: "/mdn-observatory-webext"
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:23
 
 RUN apt-get -y update && \
   apt-get install -y git && \


### PR DESCRIPTION
### Description

- upgrade Dockerfile to use the latest node image
- add Docker ecosystem to dependabot to track these upgrades automatically in the future

### Motivation

This will allow to patch security vulnerabilities in the current node:20 version and track these upgrades automatically in the future.
