### PR TITLE
fix(docker): ignore GCP token file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,7 @@ api-examples.http
 .editorconfig
 .gitignore
 .prettierrc.json
+
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182