### PR TITLE
ci(workflows): assign explicit permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+# No GITHUB_TOKEN permissions, as we use AUTOMERGE_TOKEN instead.
+permissions: {}
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Adds explicit `permissions:` configuration to workflow files that don't already have permissions defined either at the workflow level or for all jobs.

- If the workflow doesn't use `secrets.GITHUB_TOKEN` or `github.token`, sets `permissions: {}` to restrict all permissions.
- If the workflow uses the GitHub token, adds `permissions:` with required permissions.

### Motivation

Security best practice to explicitly declare `GITHUB_TOKEN` permissions instead of relying on default permissions, following the principle of least privilege by ensuring workflows only have the permissions they actually need.

### Additional details

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/924.
