### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -50,7 +50,7 @@ jobs:
           echo "✅ Valid tag: $TAG"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ inputs.ref || github.event.repository.default_branch }}
           persist-credentials: false
@@ -60,7 +60,7 @@ jobs:
 
       - name: GCP auth
         id: gcp-auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           service_account: artifact-writer@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,12 +26,12 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: ".nvmrc"
           package-manager-cache: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release
-        uses: GoogleCloudPlatform/release-please-action@v4
+        uses: GoogleCloudPlatform/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release


### PR DESCRIPTION
### Description

Pins all 3rd party GitHub Actions to specific commit hashes instead of version tags.

Each pinned action includes an inline comment with the resolved version number for reference.

### Motivation

Security best practice to pin actions to immutable commit hashes, preventing potential supply chain attacks from compromised action versions or tag hijacking.

### Additional details

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1005.