### PR TITLE
chore(Dockerfile): run `npm ci`, not `npm install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /home/node/app
 USER node
 COPY --chown=node:node . .
 # This also installs hsts and tld data files in a postinstall script:
-RUN npm install
+RUN npm ci
 
 ARG GIT_SHA=dev
 ARG RUN_ID=unknown


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `Dockerfile` to run `npm ci` instead of `npm install`.

### Motivation

Rule out that `npm install` in the Dockerfile changes the `package-lock.json`, which might give a clue for availability issues.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
