### PR TITLE
fix(db): limit connections across replicas to pg limit

### DIFF
--- a/src/database/repository.js
+++ b/src/database/repository.js
@@ -21,7 +21,7 @@ export const poolOptions = {
   password: CONFIG.database.pass,
   port: CONFIG.database.port,
   ssl: CONFIG.database.sslmode,
-  max: 40, // set pool max size to 40
+  max: 20, // pg max_connections (100) / k8s maxReplicas (5) = 20
   idleTimeoutMillis: 60000, // close idle clients after 60 seconds
   connectionTimeoutMillis: 2000, // return an error after 2 seconds if connection could not be established
   maxUses: 10000, // close (and replace) a connection after it has been used 10000 times


### PR DESCRIPTION
We've had a number of `connection to server at ... failed: FATAL:  remaining connection slots are reserved for non-replication superuser connections` errors in Sentry: this appears to be coming from postgres itself, and seems to correlate with us scaling up to our max replicas (of 5).

Our postgres max_connections is currently 100, and with 5 max replicas, that means each pod can only have 20 max connections.

According to our postgres metrics we seem to hover around 25 connections total most of the time (so around 5 connections per pod), so this shouldn't break things: we'll likely just see errors originating from inside the app, instead of postgres itself, if we don't have sufficient pool capacity. If that becomes and issue we can tune further.