### PR TITLE
chore(deps): bump npm from 11.6.2 to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Mozilla Developer Network",
   "description": "The MDN HTTP Observatory is a set of tools to analyze your website and inform you if you are utilizing the many available methods to secure it.",
   "main": "src/index.js",
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.7.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
### Description

Updates the `packageManager` field in `package.json` from `npm@11.6.2` to `npm@11.7.0`.

### Motivation

Ensures repositories use the latest npm version.

### Additional details

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1205.