### PR TITLE
ci(auto-merge): migrate away from "squash and merge" command

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,4 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
         run: |
           gh pr review ${{ github.event.pull_request.html_url }} --approve
-          gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"
+          gh pr merge ${{ github.event.pull_request.html_url }} --auto --squash


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Migrates from the no longer supported Dependabot merge comment to [GitHub auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request).

### Motivation

The "squash and merge" command is no longer supported since 2026-01-27.

### Additional details

Marked `test / {test,lint,build}` as required.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1255.