### PR TITLE
test(redirection): replace domain

### DIFF
--- a/test/redirection.test.js
+++ b/test/redirection.test.js
@@ -143,19 +143,19 @@ describe("Redirections", () => {
   it("checks for all redirections preloaded", function () {
     reqs.responses.httpRedirects = [
       {
-        url: new URL("http://pokeinthe.io/"),
+        url: new URL("http://cloudflare.com/"),
         status: 301,
       },
       {
-        url: new URL("https://pokeinthe.io/"),
+        url: new URL("https://cloudflare.com/"),
         status: 302,
       },
       {
-        url: new URL("https://www.pokeinthe.io/"),
+        url: new URL("https://www.cloudflare.com/"),
         status: 302,
       },
       {
-        url: new URL("https://baz.pokeinthe.io/foo"),
+        url: new URL("https://baz.cloudflare.com/foo"),
         status: 200,
       },
     ];


### PR DESCRIPTION
### Description

Fixes the redirection test by using a different domain.

### Motivation

Previous domain was removed from HSTS preload list.

### Additional details

Note: It would be better to use fixtures, but this should unblock the Dependabot updates for now.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
