### PR TITLE
ci(npm-publish): add missing permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,9 @@ on:
         required: true
         type: string
 
-permissions: {}
+permissions:
+  contents: read
+  id-token: write # OIDC for npm Trusted Publishing
 
 jobs:
   publish:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `npm-publish` workflow, assigning missing permissions.

### Motivation

Ensures that the workflow can authenticate with the npm registry using OIDC.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/mdn-http-observatory/pull/488.