### PR TITLE
ci(npm-publish): use npm 11.8.0 or later

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,6 +38,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
+      - name: Install npm@^11.8.0
+        run: npm install -g npm@^11.8.0
+
       - name: Install
         run: npm ci
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update `npm-publish` workflow to use npm 11.8.0 or later.

### Motivation

Unblock publishing Observatory versions like v1.4.1 that use Node 20, which is bundled with an npm version that doesn't support OIDC.

### Additional details

Same constraint as in `devEngines.packageManager.version` (`package.json`).

### Related issues and pull requests

Follow-up of https://github.com/mdn/mdn-http-observatory/pull/488.