### PR TITLE
chore(package): set repository field

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,5 +44,14 @@ jobs:
       - name: Install
         run: npm ci
 
+      # Backfill repository field for older tags.
+      # Otherwise npm provenance fails with error code E422.
+      - name: Ensure repository field in package.json
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          npm pkg set repository="$REPO_URL"
+          npm pkg fix
+
       - name: Publish to npm
         run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "mdn-http-observatory-scan": "bin/wrapper.js"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mdn/mdn-http-observatory.git"
+  },
   "license": "MPL-2.0",
   "devDependencies": {
     "@faker-js/faker": "^10.0.0",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Set `repository` field in `package.json`.

Also backfill it in the `npm-publish` workflow.

### Motivation

Satisfy requirement for npm provenance.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/mdn-http-observatory/pull/488.