### PR TITLE
ci(npm-publish): add dist-tag input

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,12 +7,22 @@ on:
         description: "Git tag to publish (e.g. v1.6.0)"
         required: true
         type: string
+      dist-tag:
+        description: "npm dist-tag (e.g. latest, next, beta)"
+        required: false
+        type: string
+        default: "latest"
   workflow_call:
     inputs:
       tag:
         description: "Git tag to publish (e.g. v1.6.0)"
         required: true
         type: string
+      dist-tag:
+        description: "npm dist-tag (e.g. latest, next, beta)"
+        required: false
+        type: string
+        default: "latest"
 
 permissions:
   contents: read
@@ -54,4 +64,4 @@ jobs:
           npm pkg fix
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ inputs.dist-tag }}


### PR DESCRIPTION
Allows publishing a non-latest version.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update the `npm-publish` workflow, adding a `dist-tag` input to specify an [npm dist-tag](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) other than `latest`.

### Motivation

Allows to publish preview versions as `next`.

### Additional details

Noticed when trying to publish 1.3.4 (for completeness sake), which npm refused, because without `--tag` it was attempting to release it as `latest`. The workaround would be to create  a dist-tag like `old-version` or `1.3.x`, then publish with that dist-tag, and remove the dist-tag later.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
