### PR TITLE
fix(analyzer/csp): split CSP headers into policies

### DIFF
--- a/src/analyzer/tests/csp.js
+++ b/src/analyzer/tests/csp.js
@@ -11,6 +11,18 @@ import {
 } from "../cspParser.js";
 import { getHttpHeaders } from "../utils.js";
 
+/**
+ * Split a list of raw CSP header values into individual policies.
+ * Per RFC 9110 §5.3, clients may combine multiple headers as a comma-separated
+ * string. Per W3C CSP3 §2.2, commas are policy-list delimiters and are excluded
+ * from the directive-value grammar, so splitting on comma is unambiguous.
+ * @param {string[]} rawHeaders
+ * @returns {string[]}
+ */
+function splitCspHeaders(rawHeaders) {
+  return rawHeaders.flatMap((v) => v.split(",").map((s) => s.trim()));
+}
+
 const DANGEROUSLY_BROAD = new Set([
   "ftp:",
   "http:",
@@ -99,7 +111,10 @@ export function contentSecurityPolicyTest(
   const equivCspHeader =
     response?.httpEquiv?.get(CONTENT_SECURITY_POLICY) ?? [];
 
-  output.numPolicies = equivCspHeader.length + httpCspHeader.length;
+  const httpCspPolicies = splitCspHeaders(httpCspHeader);
+  const equivCspPolicies = splitCspHeaders(equivCspHeader);
+
+  output.numPolicies = equivCspPolicies.length + httpCspPolicies.length;
 
   /** @type {Map<string, Set<string>>} */
   let csp;
@@ -110,7 +125,7 @@ export function contentSecurityPolicyTest(
 
   try {
     csp = parseCsp(
-      [...httpCspHeader, ...equivCspHeader].filter((x) => x !== null)
+      [...httpCspPolicies, ...equivCspPolicies].filter((x) => x !== null)
     );
   } catch (e) {
     output.result = Expectation.CspHeaderInvalid;
@@ -118,13 +133,13 @@ export function contentSecurityPolicyTest(
   }
 
   try {
-    httpHeaderOnlyCsp = parseCsp(httpCspHeader);
+    httpHeaderOnlyCsp = parseCsp(httpCspPolicies);
   } catch (e) {
     httpHeaderOnlyCsp = new Map();
   }
 
   try {
-    metaCsp = parseCspMeta(equivCspHeader);
+    metaCsp = parseCspMeta(equivCspPolicies);
   } catch (e) {
     metaCsp = new Map();
   }
@@ -149,8 +164,8 @@ export function contentSecurityPolicyTest(
   output.policy = new Policy();
 
   // mark whether we saw csp there or not
-  output.http = httpCspHeader?.length > 0;
-  output.meta = equivCspHeader?.length > 0;
+  output.http = httpCspPolicies?.length > 0;
+  output.meta = equivCspPolicies?.length > 0;
 
   // Get the various directives we look at
   const base_uri = csp.get("base-uri") || new Set(["*"]);

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -506,21 +506,23 @@ describe("Content Security Policy", () => {
 
   it("multiple CSP headers with differing policies produce correct intersection", async () => {
     // Per W3 CSP3 section 8.1, when multiple policies are in effect, all must be satisfied.
-    // Policy 1 allows 'unsafe-inline' in style-src; policy 2 does not.
-    // The effective policy (intersection) should restrict style-src to only 'self'.
+    // The restrictive middle policy (no 'unsafe-inline', no script-src) is sandwiched between
+    // two permissive outer policies. The effective policy (intersection) must restrict
+    // style-src to only 'self' and may not be satisfied by simply taking the first or last policy.
     // See: https://github.com/mdn/mdn-http-observatory/issues/463
     const requests = emptyRequests();
     setHeader(
       requests.responses.auto,
       "Content-Security-Policy",
       "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline', " +
-        "default-src 'none'; script-src 'self'; style-src 'self'"
+        "default-src 'none'; style-src 'self', " +
+        "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'"
     );
 
     const result = contentSecurityPolicyTest(requests);
 
     assert.notEqual(result["result"], Expectation.CspHeaderInvalid);
-    assert.equal(result["numPolicies"], 2);
+    assert.equal(result["numPolicies"], 3);
     assert.isFalse(result["policy"]?.unsafeInlineStyle);
     assert.isTrue(result["pass"]);
     assert.deepEqual(result["data"], {

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -480,6 +480,56 @@ describe("Content Security Policy", () => {
       Expectation.CspNotImplementedButReportingEnabled
     );
   });
+  it("multiple CSP headers combined per RFC 9110 are not treated as invalid", async () => {
+    // Per RFC 9110 section 5.3, when a server sends multiple Content-Security-Policy headers,
+    // HTTP clients may combine them as a comma-separated list in a single field.
+    // Per W3 CSP3 section 8.1, each policy in the list must be enforced independently.
+    // The Observatory must not reject such comma-separated CSP policy lists as invalid.
+    // See: https://github.com/mdn/mdn-http-observatory/issues/463
+    const requests = emptyRequests();
+    setHeader(
+      requests.responses.auto,
+      "Content-Security-Policy",
+      "default-src 'none'; script-src 'self', default-src 'none'; script-src 'self'"
+    );
+
+    const result = contentSecurityPolicyTest(requests);
+
+    assert.notEqual(result["result"], Expectation.CspHeaderInvalid);
+    assert.equal(result["numPolicies"], 2);
+    assert.isTrue(result["pass"]);
+    assert.deepEqual(result["data"], {
+      "default-src": ["'none'"],
+      "script-src": ["'self'"],
+    });
+  });
+
+  it("multiple CSP headers with differing policies produce correct intersection", async () => {
+    // Per W3 CSP3 section 8.1, when multiple policies are in effect, all must be satisfied.
+    // Policy 1 allows 'unsafe-inline' in style-src; policy 2 does not.
+    // The effective policy (intersection) should restrict style-src to only 'self'.
+    // See: https://github.com/mdn/mdn-http-observatory/issues/463
+    const requests = emptyRequests();
+    setHeader(
+      requests.responses.auto,
+      "Content-Security-Policy",
+      "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline', " +
+        "default-src 'none'; script-src 'self'; style-src 'self'"
+    );
+
+    const result = contentSecurityPolicyTest(requests);
+
+    assert.notEqual(result["result"], Expectation.CspHeaderInvalid);
+    assert.equal(result["numPolicies"], 2);
+    assert.isFalse(result["policy"]?.unsafeInlineStyle);
+    assert.isTrue(result["pass"]);
+    assert.deepEqual(result["data"], {
+      "default-src": ["'none'"],
+      "script-src": ["'self'"],
+      "style-src": ["'self'"],
+    });
+  });
+
   it("ignore frame-anchestors in http-equiv", async () => {
     let requests = emptyRequests(
       "test_parse_http_equiv_headers_not_allowed.html"


### PR DESCRIPTION
### Description

Update the CSP analyzer, splitting raw `Content-Security-Policy` header values on `,` before parsing.

### Motivation

Prevent sites with valid multi-policy CSP configurations from receiving a -25 point penalty with `csp-header-invalid`.

### Additional details

Per RFC 9110 §5.3, HTTP clients may combine multiple `Content-Security-Policy`
headers into a single comma-separated string. The observatory was passing this
combined string directly to `parseCsp()` as one policy, which saw duplicate
directives (e.g. two `default-src`) and threw.

Using the host [mentioned in the issue](https://github.com/mdn/mdn-http-observatory/issues/463#issuecomment-4094685172):

```diff
diff --git a/before.json b/after.json
index 160c606..0158e9e 100644
--- a/before.json
+++ b/after.json
@@ -1,23 +1,23 @@
 {
   "scan": {
     "algorithmVersion": 5,
-    "grade": "B",
+    "grade": "A+",
     "error": null,
-    "score": 75,
+    "score": 130,
     "statusCode": 200,
-    "testsFailed": 1,
-    "testsPassed": 9,
+    "testsFailed": 0,
+    "testsPassed": 10,
     "testsQuantity": 10,
     "responseHeaders": {
       "server": "nginx",
-      "date": "Fri, 10 Apr 2026 16:03:44 GMT",
+      "date": "Fri, 10 Apr 2026 16:04:00 GMT",
       "content-type": "text/html; charset=UTF-8",
       "transfer-encoding": "chunked",
       "connection": "close",
       "cache-control": "no-cache",
       "content-security-policy": "default-src 'none'; style-src 'self' 'sha256-uwxWvxXGaIKENPedXo3PWxEjiMY/TKGVhYsgJZiFN0k=' https://fonts.googleapis.com https://cdnjs.cloudflare.com; script-src 'self' 'sha256-vIHOuWOxI9X8ELXotMLZzui9qzFH8JyoJQJxXcfqXss='; base-uri 'none'; child-src 'none'; connect-src 'self'; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; form-action 'self'; frame-ancestors 'none'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'none'; worker-src 'self'; require-trusted-types-for 'script'; upgrade-insecure-requests; report-uri csp-endpoint; report-to csp-endpoint;, default-src 'none'; style-src 'self' 'unsafe-hashes' 'sha256-uwxWvxXGaIKENPedXo3PWxEjiMY/TKGVhYsgJZiFN0k=' 'sha256-o6wwKqYRd2hQg9bzo4haG7KPbOUce1w+3vvf5Fb4v3U=' 'sha256-kvWAb9InqR51HMSqIS2HezX8j6vjW+3Ei31y+vTysh4=' 'sha256-0EZqoz+oBhx7gF4nvY2bSqoGyy4zLjNF+SDQXGp/ZrY=' https://fonts.googleapis.com https://cdnjs.cloudflare.com; script-src 'self' 'sha256-vIHOuWOxI9X8ELXotMLZzui9qzFH8JyoJQJxXcfqXss='; base-uri 'none'; child-src 'none'; connect-src 'self'; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; form-action 'self'; frame-ancestors 'none'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'none'; worker-src 'self'; upgrade-insecure-requests; report-uri csp-endpoint; report-to csp-endpoint;",
       "etag": "W/\"69d8e486-353a\"",
-      "expires": "Fri, 10 Apr 2026 15:41:27 GMT",
+      "expires": "Fri, 10 Apr 2026 15:41:43 GMT",
       "last-modified": "Fri, 10 Apr 2026 11:52:38 GMT",
       "vary": "Accept-Encoding",
       "allow": "GET, POST, HEAD",
@@ -35,14 +35,89 @@
   "tests": {
     "content-security-policy": {
       "expectation": "csp-implemented-with-no-unsafe",
-      "pass": false,
-      "result": "csp-header-invalid",
-      "scoreModifier": -25,
-      "data": null,
-      "http": false,
+      "pass": true,
+      "result": "csp-implemented-with-no-unsafe-default-src-none",
+      "scoreModifier": 10,
+      "data": {
+        "default-src": [
+          "'none'"
+        ],
+        "style-src": [
+          "'self'",
+          "'sha256-uwxwvxxgaikenpedxo3pwxejimy/tkgvhysgjzifn0k='",
+          "https://cdnjs.cloudflare.com",
+          "https://fonts.googleapis.com"
+        ],
+        "script-src": [
+          "'self'",
+          "'sha256-vihouwoxi9x8elxotmlzzui9qzfh8jyojqjxxcfqxss='"
+        ],
+        "base-uri": [
+          "'none'"
+        ],
+        "child-src": [
+          "'none'"
+        ],
+        "connect-src": [
+          "'self'"
+        ],
+        "font-src": [
+          "'self'",
+          "data:",
+          "https://cdnjs.cloudflare.com",
+          "https://fonts.gstatic.com"
+        ],
+        "form-action": [
+          "'self'"
+        ],
+        "frame-ancestors": [
+          "'none'"
+        ],
+        "frame-src": [
+          "'self'"
+        ],
+        "img-src": [
+          "'self'",
+          "data:"
+        ],
+        "media-src": [
+          "'self'"
+        ],
+        "object-src": [
+          "'none'"
+        ],
+        "worker-src": [
+          "'self'"
+        ],
+        "require-trusted-types-for": [
+          "'script'"
+        ],
+        "upgrade-insecure-requests": [
+          "'none'"
+        ],
+        "report-uri": [
+          "csp-endpoint"
+        ],
+        "report-to": [
+          "csp-endpoint"
+        ]
+      },
+      "http": true,
       "meta": false,
-      "policy": null,
-      "numPolicies": 1
+      "policy": {
+        "antiClickjacking": true,
+        "defaultNone": true,
+        "insecureBaseUri": false,
+        "insecureFormAction": false,
+        "insecureSchemeActive": false,
+        "insecureSchemePassive": false,
+        "strictDynamic": false,
+        "unsafeEval": false,
+        "unsafeInline": false,
+        "unsafeInlineStyle": false,
+        "unsafeObjects": false
+      },
+      "numPolicies": 2
     },
     "cookies": {
       "expectation": "cookies-secure-with-httponly-sessions",
@@ -109,7 +184,7 @@
     "x-frame-options": {
       "expectation": "x-frame-options-sameorigin-or-deny",
       "pass": true,
-      "result": "x-frame-options-sameorigin-or-deny",
+      "result": "x-frame-options-implemented-via-csp",
       "scoreModifier": 5,
       "data": "DENY"
     },

```

### Related issues and pull requests

Fixes #463