### PR TITLE
ci(test): test Node 26 instead of Node 25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
           - windows-latest
         node-version:
           - 24
-          - 25
+          - 26
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update the `test` workflow to use Node 26 instead of Node 25 in the test matrix.

### Motivation

Node 26 is out, and Node 26 no longer has active support, with security support ending on 2026-06-01.

### Additional details

In order to merge, need to unmark the node-25 tests as required, and mark the node-26 tests as required.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
