### PR TITLE
refactor(api): replace `ip` dependency with `node:net` `isIP`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "fastify-simple-form": "^3.0.0",
         "htmlparser2": "^12.0.0",
         "http-cookie-agent": "^8.0.0",
-        "ip": "^2.0.1",
         "node_extra_ca_certs_mozilla_bundle": "^1.0.7",
         "pg": "^8.16.2",
         "pg-format": "^1.0.4",
@@ -2604,11 +2603,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "fastify-simple-form": "^3.0.0",
     "htmlparser2": "^12.0.0",
     "http-cookie-agent": "^8.0.0",
-    "ip": "^2.0.1",
     "node_extra_ca_certs_mozilla_bundle": "^1.0.7",
     "pg": "^8.16.2",
     "pg-format": "^1.0.4",

--- a/src/api/v2/utils.js
+++ b/src/api/v2/utils.js
@@ -1,5 +1,5 @@
-import ip from "ip";
 import dns from "node:dns";
+import net from "node:net";
 import fs from "fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -35,9 +35,7 @@ import { scan } from "../../scanner/index.js";
  * @returns {boolean}
  */
 export function isIp(hostname) {
-  if (ip.isV4Format(hostname)) return true;
-  if (ip.isV6Format(hostname)) return true;
-  return false;
+  return net.isIP(hostname) !== 0;
 }
 
 /**

--- a/test/apiv2-utils.test.js
+++ b/test/apiv2-utils.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import { assert } from "chai";
+import { isIp } from "../src/api/v2/utils.js";
+
+describe("isIp", () => {
+  it("returns true for valid IPv4 and IPv6 addresses", function () {
+    assert.isTrue(isIp("1.2.3.4"));
+    assert.isTrue(isIp("127.0.0.1"));
+    assert.isTrue(isIp("::1"));
+    assert.isTrue(isIp("2001:db8::1"));
+  });
+
+  it("returns false for hostnames and malformed addresses", function () {
+    assert.isFalse(isIp("example.com"));
+    assert.isFalse(isIp("999.1.1.1"));
+    assert.isFalse(isIp("1.2.3.4.5"));
+    assert.isFalse(isIp("1::2::3"));
+    assert.isFalse(isIp(""));
+  });
+});


### PR DESCRIPTION
### Description

Replace the `ip` package with the built-in `node:net` module in `isIp()`:

- Use `net.isIP()` instead of `ip.isV4Format`/`ip.isV6Format`, removing the `ip` dependency entirely.
- Add tests for `isIp()`, which previously had no coverage.

### Motivation

Ensure IP-address detection stays correct without depending on an external package. `net.isIP()` is stricter than the `ip` library's regexes, which accept malformed inputs such as `999.1.1.1` and `1::2::3` as valid addresses. The only usage in the codebase is the `isIp()` guard that rejects raw IP inputs, so the built-in fully covers it with no new dependency.

### Additional details

| input | `ip` (before) | `net.isIP` (after) |
|---|---|---|
| `999.1.1.1` | valid | rejected |
| `1::2::3` | valid | rejected |

`ipaddr.js` was also considered (it is the de-facto choice across the mozilla/mdn orgs and already present transitively via `@fastify/proxy-addr`), but `net.isIP()` needs no dependency and is stricter for this use case. `netmask` was ruled out as IPv4-only.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->