### PR TITLE
chore(deps): remove leftover `@types/ip`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@supercharge/promise-pool": "^3.2.0",
         "@types/chai": "^5.2.2",
         "@types/convict": "^6.1.6",
-        "@types/ip": "^1.1.3",
         "@types/pg": "^8.20.0",
         "@types/pg-format": "^1.0.5",
         "@types/tough-cookie": "^4.0.5",
@@ -861,15 +860,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
-    },
-    "node_modules/@types/ip": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.3.tgz",
-      "integrity": "sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@supercharge/promise-pool": "^3.2.0",
     "@types/chai": "^5.2.2",
     "@types/convict": "^6.1.6",
-    "@types/ip": "^1.1.3",
     "@types/pg": "^8.20.0",
     "@types/pg-format": "^1.0.5",
     "@types/tough-cookie": "^4.0.5",


### PR DESCRIPTION
### Description

Remove the `@types/ip` dev dependency.

### Motivation

Ensure the dependency tree stays clean: [#541](https://github.com/mdn/mdn-http-observatory/pull/541) removed the `ip` runtime dependency but left its `@types/ip` type package behind, which serves no purpose without `ip` installed.

### Additional details

`npx tsc -p jsconfig.json --noEmit` still passes after the removal.

### Related issues and pull requests

Follow-up to #541.