### PR TITLE
build(deps): omit dev-dep bumps from release changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,5 @@ updates:
           - "@mdn/*"
     commit-message:
       prefix: chore
+      prefix-development: build
       include: scope


### PR DESCRIPTION
### Description

Update `.github/dependabot.yml` to set `commit-message.prefix-development: build`, so Dependabot dev-dep bumps land as `build(deps-dev): ...` instead of `chore(deps-dev): ...`.

### Motivation

Ensure dev-dep bumps don't clutter the release changelog. The `build` type isn't listed in `release-please-config.json`'s `changelog-sections` and is therefore hidden by default. Prod-dep bumps remain `chore(deps): ...` and stay visible under "Miscellaneous".

### Additional details

Existing open Dependabot PRs will keep their `chore(deps-dev)` titles until rebased/recreated.

Replicates mdn/fred#1572.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->