### PR TITLE
ci(release-please): set `GH_TOKEN` and correct `tag_name` output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,4 +31,5 @@ jobs:
             --ref "$TAG_NAME" \
             -f tag="$TAG_NAME"
         env:
-          TAG_NAME: ${{ steps.release.outputs.outputs.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Description

Fix the `Publish` step in `release-please.yml`:

- Add `GH_TOKEN` to the step's `env` so `gh workflow run` can authenticate.
- Correct the `TAG_NAME` expression from `steps.release.outputs.outputs.tag_name` (doubled `outputs`) to `steps.release.outputs.tag_name`.

## Motivation

Ensure a created release is automatically published to npm. Without these fixes, releases are tagged on GitHub but the npm publish is never dispatched (v1.6.3 was released but npm `latest` is still `1.6.2`).

## Additional details

`github.token` is sufficient: `workflow_dispatch` is a documented exception to the "GITHUB_TOKEN doesn't trigger new runs" rule, and the workflow already grants `actions: write`. Failing run: https://github.com/mdn/mdn-http-observatory/actions/runs/29510236027/job/87661465017

## Related issues and pull requests

Fixes #564.
