### PR TITLE
fix(api): report unscannable sites as 422 instead of 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ If an error occurred, an object like this is returned:
 }
 ```
 
+Hosts that cannot be scanned, because they are invalid, unresolvable, unreachable, or answer with an unexpected HTTP status code, are reported with a `422 Unprocessable Content` status. A `500 Internal Server Error` status indicates a problem on our side.
+
 ## Migrating from the public V1 API to the V2 API
 
 ### Sunset of the V1 API

--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -11,9 +11,22 @@ export class AppError extends Error {
 
 export class SiteIsDownError extends AppError {
   constructor() {
-    super("Site is down");
+    super("The site seems to be down.");
     this.name = "site-down";
-    this.statusCode = STATUS_CODES.badRequest;
+    this.statusCode = STATUS_CODES.unprocessableEntity;
+  }
+}
+
+export class UnexpectedStatusCodeError extends AppError {
+  /**
+   * @param {number} responseStatusCode - The status code the scanned site responded with
+   */
+  constructor(responseStatusCode) {
+    super(
+      `Site did respond with an unexpected HTTP status code ${responseStatusCode}.`
+    );
+    this.name = "unexpected-status-code";
+    this.statusCode = STATUS_CODES.unprocessableEntity;
   }
 }
 
@@ -31,7 +44,11 @@ export class ScanFailedError extends AppError {
   constructor(e) {
     super("Scan Failed");
     this.name = "scan-failed";
-    this.statusCode = STATUS_CODES.internalServerError;
+    // A scan can fail because the scanned site is unusable, which is not our
+    // fault. Keep the status code of the underlying `AppError` in that case,
+    // and only report a server error for genuinely unexpected failures.
+    this.statusCode =
+      e instanceof AppError ? e.statusCode : STATUS_CODES.internalServerError;
     this.message = e.message;
   }
 }

--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -23,7 +23,7 @@ export class UnexpectedStatusCodeError extends AppError {
    */
   constructor(responseStatusCode) {
     super(
-      `Site did respond with an unexpected HTTP status code ${responseStatusCode}.`
+      `Site responded with an unexpected HTTP status code ${responseStatusCode}.`
     );
     this.name = "unexpected-status-code";
     this.statusCode = STATUS_CODES.unprocessableEntity;
@@ -44,9 +44,6 @@ export class ScanFailedError extends AppError {
   constructor(e) {
     super("Scan Failed");
     this.name = "scan-failed";
-    // A scan can fail because the scanned site is unusable, which is not our
-    // fault. Keep the status code of the underlying `AppError` in that case,
-    // and only report a server error for genuinely unexpected failures.
     this.statusCode =
       e instanceof AppError ? e.statusCode : STATUS_CODES.internalServerError;
     this.message = e.message;

--- a/src/scanner/index.js
+++ b/src/scanner/index.js
@@ -1,3 +1,4 @@
+import { SiteIsDownError, UnexpectedStatusCodeError } from "../api/errors.js";
 import { ALGORITHM_VERSION, ALL_TESTS, NUM_TESTS } from "../constants.js";
 import { MINIMUM_SCORE_FOR_EXTRA_CREDIT } from "../grader/charts.js";
 import {
@@ -23,15 +24,13 @@ import { retrieve } from "../retriever/retriever.js";
 export function analyzeScan(requests) {
   if (!requests.responses.auto) {
     // We cannot connect at all, abort the test.
-    throw new Error("The site seems to be down.");
+    throw new SiteIsDownError();
   }
 
   // We allow 2xx, 3xx, 401 and 403 status codes
   const { status } = requests.responses.auto;
   if (status < 200 || (status >= 400 && ![401, 403].includes(status))) {
-    throw new Error(
-      `Site did respond with an unexpected HTTP status code ${status}.`
-    );
+    throw new UnexpectedStatusCodeError(status);
   }
 
   // Run all the tests on the result

--- a/test/api-errors.test.js
+++ b/test/api-errors.test.js
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+
+import { assert } from "chai";
+
+import {
+  InvalidHostNameError,
+  ScanFailedError,
+  SiteIsDownError,
+  UnexpectedStatusCodeError,
+} from "../src/api/errors.js";
+
+describe("ScanFailedError", () => {
+  /**
+   * @type {{ label: string, cause: Error, statusCode: number }[]}
+   */
+  const cases = [
+    {
+      label: "an unreachable site",
+      cause: new SiteIsDownError(),
+      statusCode: 422,
+    },
+    {
+      label: "an unexpected response status code",
+      cause: new UnexpectedStatusCodeError(503),
+      statusCode: 422,
+    },
+    {
+      label: "an invalid hostname",
+      cause: new InvalidHostNameError(),
+      statusCode: 422,
+    },
+    {
+      label: "an unexpected internal failure",
+      cause: new Error("something broke"),
+      statusCode: 500,
+    },
+  ];
+
+  for (const { label, cause, statusCode } of cases) {
+    it(`reports ${statusCode} for ${label}`, function () {
+      const error = new ScanFailedError(cause);
+      assert.equal(error.statusCode, statusCode);
+      assert.equal(error.name, "scan-failed");
+      assert.equal(error.message, cause.message);
+    });
+  }
+});

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -2,10 +2,11 @@ import { describe, it } from "node:test";
 
 import { assert } from "chai";
 
-import { scan } from "../src/scanner/index.js";
+import { AppError } from "../src/api/errors.js";
+import { analyzeScan, scan } from "../src/scanner/index.js";
 import { Site } from "../src/site.js";
 
-import { fixtureRequests, scanWithRequests } from "./helpers.js";
+import { emptyRequests, fixtureRequests, scanWithRequests } from "./helpers.js";
 
 /** @typedef {import("../src/scanner/index.js").ScanResult} ScanResult */
 
@@ -21,11 +22,57 @@ describe("Scanner", () => {
       await scan(site);
       throw new Error("scan should throw");
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof AppError) {
         assert.equal(error.message, "The site seems to be down.");
+        assert.equal(error.statusCode, 422);
       } else {
         throw new Error("Unexpected error type", { cause: error });
       }
+    }
+  });
+
+  describe("reports unusable sites as unprocessable", () => {
+    /**
+     * @type {{ label: string, status: number | null, name: string, message: string }[]}
+     */
+    const cases = [
+      {
+        label: "no response at all",
+        status: null,
+        name: "site-down",
+        message: "The site seems to be down.",
+      },
+      ...[100, 400, 404, 500].map((status) => ({
+        label: `a ${status} response`,
+        status,
+        name: "unexpected-status-code",
+        message: `Site did respond with an unexpected HTTP status code ${status}.`,
+      })),
+    ];
+
+    for (const { label, status, name, message } of cases) {
+      it(label, function () {
+        const requests = emptyRequests();
+        if (status === null) {
+          requests.responses.auto = null;
+        } else {
+          assert(requests.responses.auto);
+          requests.responses.auto.status = status;
+        }
+
+        try {
+          analyzeScan(requests);
+          throw new Error("analyzeScan should throw");
+        } catch (error) {
+          if (error instanceof AppError) {
+            assert.equal(error.name, name);
+            assert.equal(error.message, message);
+            assert.equal(error.statusCode, 422);
+          } else {
+            throw new Error("Unexpected error type", { cause: error });
+          }
+        }
+      });
     }
   });
 

--- a/test/scanner.test.js
+++ b/test/scanner.test.js
@@ -46,7 +46,7 @@ describe("Scanner", () => {
         label: `a ${status} response`,
         status,
         name: "unexpected-status-code",
-        message: `Site did respond with an unexpected HTTP status code ${status}.`,
+        message: `Site responded with an unexpected HTTP status code ${status}.`,
       })),
     ];
 


### PR DESCRIPTION
### Description

Fix `/api/v2/scan` and `/api/v2/analyze` to report unscannable target sites with a `422 Unprocessable Content` status instead of `500 Internal Server Error`.

- Throw `SiteIsDownError` and the new `UnexpectedStatusCodeError` from `analyzeScan()`, instead of plain `Error`s.
- Let `ScanFailedError` keep the status code of the underlying `AppError`, and only fall back to 500 for plain `Error`s.
- Change `SiteIsDownError` to 422, and align its message with the one `analyzeScan()` already used.

Response bodies are unchanged. These failures are still reported as `{"error": "scan-failed", "message": "..."}`, only the status code differs.

### Motivation

Ensure that a `500` from the API means a problem on our side, rather than the site that a client asked us to scan being unreachable. Today a scan of a host that resolves but does not answer produces:

```
HTTP/1.1 500 Internal Server Error

{"error":"scan-failed","message":"The site seems to be down."}
```

This inflates the origin error rate in Fastly/SigSci dashboards and trips their `HTTPErrorRule` signal, which makes it harder to notice real server problems. `422` is what the API already returns for the other unscannable-host cases (`invalid-hostname`, `invalid-hostname-ip`, `invalid-hostname-lookup`, `invalid-site`).

### Additional details

`analyzeScan()` threw plain `Error`s, and `executeScan()` rewrapped every failure into `ScanFailedError`, which hard-coded a 500. That rewrapping also swallowed the status code of `SiteIsDownError`: it is raised from `detectTlsSupport()` during TLS detection, inside `scan()`, so its `400` never reached clients. It is now reachable and returns `422`.

Behavior change, by status code:

| Condition | Before | After |
| --- | --- | --- |
| Target does not respond at all | 500 | 422 |
| Target responds with an unexpected status code | 500 | 422 |
| TLS detection finds no listener on a custom port | 500 | 422 |
| Anything else (bugs, DB failures, …) | 500 | 500 |

The only user-facing copy change is in the README:

```diff
+Hosts that cannot be scanned, because they are invalid, unresolvable, unreachable, or answer
+with an unexpected HTTP status code, are reported with a `422 Unprocessable Content` status.
+A `500 Internal Server Error` status indicates a problem on our side.
```

Tested by adding `test/api-errors.test.js` for the status propagation in `ScanFailedError`, and a table-driven case in `test/scanner.test.js` for the errors `analyzeScan()` throws. Verified that both fail against `main` (7 failures, and `test/api-errors.test.js` does not load at all).

No end-to-end API test for the 422: triggering it requires a host that resolves but does not answer, which is flaky over the network. Coverage sits at the `analyzeScan()` and `ScanFailedError` level instead.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
