### PR TITLE
fix(redirection): check for missing redirection before the preload check

### DIFF
--- a/src/analyzer/tests/redirection.js
+++ b/src/analyzer/tests/redirection.js
@@ -37,46 +37,50 @@ export function redirectionTest(
   expectation = Expectation.RedirectionToHttps
 ) {
   const output = new RedirectionOutput(expectation);
-  const response = requests.responses.http;
+  const {
+    http: httpResponse,
+    httpRedirects,
+    httpsRedirects,
+  } = requests.responses;
 
-  if (requests.responses.httpRedirects.length > 0) {
-    output.destination =
-      requests.responses.httpRedirects.at(-1)?.url?.href || null;
-  } else if (requests.responses.httpsRedirects.length > 0) {
-    output.destination =
-      requests.responses.httpsRedirects.at(-1)?.url?.href || null;
+  // For display only: prefer the HTTP chain's destination, falling back to the
+  // HTTPS chain when there is no HTTP response.
+  const lastRedirect = httpRedirects.at(-1) ?? httpsRedirects.at(-1);
+  const destination = lastRedirect?.url?.href;
+  if (destination) {
+    output.destination = destination;
   }
-  output.statusCode = response ? response.status : null;
+  output.statusCode = httpResponse ? httpResponse.status : null;
 
-  if (!response) {
+  if (!httpResponse) {
     output.result = Expectation.RedirectionNotNeededNoHttp;
-  } else if (!response.verified) {
+  } else if (!httpResponse.verified) {
     output.result = Expectation.RedirectionInvalidCert;
   } else {
-    const route = requests.responses.httpRedirects;
-    output.route = route.map((r) => r.url.href);
+    output.route = httpRedirects.map((r) => r.url.href);
 
-    // Check to see if every redirection was covered by the preload list
-    const allRedirectsPreloaded = route.every((re) =>
-      isHstsPreloaded(Site.fromSiteString(re.url.hostname))
-    );
-    if (allRedirectsPreloaded) {
-      output.result = Expectation.RedirectionAllRedirectsPreloaded;
-    } else if (route.length === 1) {
+    if (httpRedirects.length === 1) {
       // No redirection, so you just stayed on the http website
       output.result = Expectation.RedirectionMissing;
       output.redirects = false;
-    } else if (route.at(-1)?.url.protocol !== "https:") {
+    } else if (
+      // Check to see if every redirection was covered by the preload list
+      httpRedirects.every((re) =>
+        isHstsPreloaded(Site.fromSiteString(re.url.hostname))
+      )
+    ) {
+      output.result = Expectation.RedirectionAllRedirectsPreloaded;
+    } else if (httpRedirects.at(-1)?.url.protocol !== "https:") {
       // Final destination wasn't an https website
       output.result = Expectation.RedirectionNotToHttps;
-    } else if (route[1]?.url.protocol === "http:") {
+    } else if (httpRedirects[1]?.url.protocol === "http:") {
       // http should never redirect to another http location -- should always go to https first
       output.result = Expectation.RedirectionNotToHttpsOnInitialRedirection;
-      output.statusCode = route.at(-1)?.status || null;
+      output.statusCode = httpRedirects.at(-1)?.status || null;
     } else if (
-      route[0]?.url.protocol === "http:" &&
-      route[1]?.url.protocol === "https:" &&
-      route[0]?.url.hostname !== route[1]?.url.hostname
+      httpRedirects[0]?.url.protocol === "http:" &&
+      httpRedirects[1]?.url.protocol === "https:" &&
+      httpRedirects[0]?.url.hostname !== httpRedirects[1]?.url.hostname
     ) {
       output.result = Expectation.RedirectionOffHostFromHttp;
     } else {

--- a/src/analyzer/tests/redirection.js
+++ b/src/analyzer/tests/redirection.js
@@ -43,8 +43,7 @@ export function redirectionTest(
     httpsRedirects,
   } = requests.responses;
 
-  // For display only: prefer the HTTP chain's destination, falling back to the
-  // HTTPS chain when there is no HTTP response.
+  // Display only; pass/fail is decided by the HTTP chain below.
   const lastRedirect = httpRedirects.at(-1) ?? httpsRedirects.at(-1);
   const destination = lastRedirect?.url?.href;
   if (destination) {
@@ -60,14 +59,12 @@ export function redirectionTest(
     output.route = httpRedirects.map((r) => r.url.href);
 
     if (httpRedirects.length === 1) {
-      // No redirection, so you just stayed on the http website
       output.result = Expectation.RedirectionMissing;
       output.redirects = false;
     } else if (httpRedirects.at(-1)?.url.protocol !== "https:") {
-      // Final destination wasn't an https website
       output.result = Expectation.RedirectionNotToHttps;
     } else if (httpRedirects[1]?.url.protocol === "http:") {
-      // http should never redirect to another http location -- should always go to https first
+      // The first hop must go to https, not to another http location.
       output.result = Expectation.RedirectionNotToHttpsOnInitialRedirection;
       output.statusCode = httpRedirects.at(-1)?.status || null;
     } else if (
@@ -83,7 +80,6 @@ export function redirectionTest(
     ) {
       output.result = Expectation.RedirectionAllRedirectsPreloaded;
     } else {
-      // Yeah, you're good
       output.result = Expectation.RedirectionToHttps;
     }
   }

--- a/src/analyzer/tests/redirection.js
+++ b/src/analyzer/tests/redirection.js
@@ -37,11 +37,8 @@ export function redirectionTest(
   expectation = Expectation.RedirectionToHttps
 ) {
   const output = new RedirectionOutput(expectation);
-  const {
-    http: httpResponse,
-    httpRedirects,
-    httpsRedirects,
-  } = requests.responses;
+  const response = requests.responses.http;
+  const { httpRedirects, httpsRedirects } = requests.responses;
 
   // Display only; pass/fail is decided by the HTTP chain below.
   const lastRedirect = httpRedirects.at(-1) ?? httpsRedirects.at(-1);
@@ -49,11 +46,11 @@ export function redirectionTest(
   if (destination) {
     output.destination = destination;
   }
-  output.statusCode = httpResponse ? httpResponse.status : null;
+  output.statusCode = response ? response.status : null;
 
-  if (!httpResponse) {
+  if (!response) {
     output.result = Expectation.RedirectionNotNeededNoHttp;
-  } else if (!httpResponse.verified) {
+  } else if (!response.verified) {
     output.result = Expectation.RedirectionInvalidCert;
   } else {
     output.route = httpRedirects.map((r) => r.url.href);

--- a/src/analyzer/tests/redirection.js
+++ b/src/analyzer/tests/redirection.js
@@ -63,13 +63,6 @@ export function redirectionTest(
       // No redirection, so you just stayed on the http website
       output.result = Expectation.RedirectionMissing;
       output.redirects = false;
-    } else if (
-      // Check to see if every redirection was covered by the preload list
-      httpRedirects.every((re) =>
-        isHstsPreloaded(Site.fromSiteString(re.url.hostname))
-      )
-    ) {
-      output.result = Expectation.RedirectionAllRedirectsPreloaded;
     } else if (httpRedirects.at(-1)?.url.protocol !== "https:") {
       // Final destination wasn't an https website
       output.result = Expectation.RedirectionNotToHttps;
@@ -83,6 +76,12 @@ export function redirectionTest(
       httpRedirects[0]?.url.hostname !== httpRedirects[1]?.url.hostname
     ) {
       output.result = Expectation.RedirectionOffHostFromHttp;
+    } else if (
+      httpRedirects.every((re) =>
+        isHstsPreloaded(Site.fromSiteString(re.url.hostname))
+      )
+    ) {
+      output.result = Expectation.RedirectionAllRedirectsPreloaded;
     } else {
       // Yeah, you're good
       output.result = Expectation.RedirectionToHttps;

--- a/test/redirection.test.js
+++ b/test/redirection.test.js
@@ -144,6 +144,40 @@ describe("Redirections", () => {
     assert.isFalse(res.pass);
   });
 
+  it("uses the https chain for the destination when there is no http response", function () {
+    reqs.responses.http = null;
+    reqs.responses.httpRedirects = [];
+    reqs.responses.httpsRedirects = [
+      {
+        url: new URL("https://mozilla.org/"),
+        status: 301,
+      },
+      {
+        url: new URL("https://www.mozilla.org/"),
+        status: 200,
+      },
+    ];
+
+    const res = redirectionTest(reqs);
+    assert.equal(res.result, Expectation.RedirectionNotNeededNoHttp);
+    assert.isTrue(res.pass);
+    assert.equal(res.destination, "https://www.mozilla.org/");
+    assert.deepEqual(res.route, []);
+  });
+
+  it("does not treat a single preloaded redirect as all-redirects-preloaded", function () {
+    reqs.responses.httpRedirects = [
+      {
+        url: new URL("http://cloudflare.com/"),
+        status: 200,
+      },
+    ];
+
+    const res = redirectionTest(reqs);
+    assert.equal(res.result, Expectation.RedirectionMissing);
+    assert.isFalse(res.pass);
+  });
+
   it("checks for all redirections preloaded", function () {
     reqs.responses.httpRedirects = [
       {

--- a/test/redirection.test.js
+++ b/test/redirection.test.js
@@ -165,17 +165,48 @@ describe("Redirections", () => {
     assert.deepEqual(res.route, []);
   });
 
-  it("does not treat a single preloaded redirect as all-redirects-preloaded", function () {
-    reqs.responses.httpRedirects = [
+  it("does not mask other checks with a preloaded redirect chain", function () {
+    const cases = [
       {
-        url: new URL("http://cloudflare.com/"),
-        status: 200,
+        name: "missing redirection",
+        httpRedirects: [
+          { url: new URL("http://cloudflare.com/"), status: 200 },
+        ],
+        expected: Expectation.RedirectionMissing,
+      },
+      {
+        name: "redirection not to https",
+        httpRedirects: [
+          { url: new URL("http://cloudflare.com/"), status: 301 },
+          { url: new URL("http://www.cloudflare.com/"), status: 200 },
+        ],
+        expected: Expectation.RedirectionNotToHttps,
+      },
+      {
+        name: "first redirection to http",
+        httpRedirects: [
+          { url: new URL("http://cloudflare.com/"), status: 301 },
+          { url: new URL("http://www.cloudflare.com/"), status: 301 },
+          { url: new URL("https://www.cloudflare.com/"), status: 200 },
+        ],
+        expected: Expectation.RedirectionNotToHttpsOnInitialRedirection,
+      },
+      {
+        name: "first redirection off host",
+        httpRedirects: [
+          { url: new URL("http://cloudflare.com/"), status: 301 },
+          { url: new URL("https://www.cloudflare.com/"), status: 200 },
+        ],
+        expected: Expectation.RedirectionOffHostFromHttp,
       },
     ];
 
-    const res = redirectionTest(reqs);
-    assert.equal(res.result, Expectation.RedirectionMissing);
-    assert.isFalse(res.pass);
+    for (const { name, httpRedirects, expected } of cases) {
+      reqs.responses.httpRedirects = httpRedirects;
+      const res = redirectionTest(reqs);
+      assert.equal(res.result, expected, name);
+      assert.isFalse(res.pass, name);
+    }
   });
 
   it("checks for all redirections preloaded", function () {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Fix the redirection test to check for a missing redirection and for a non-HTTPS final destination before the "all redirects preloaded" check.

- Order the checks as: missing, not to HTTPS, all redirects preloaded, first hop to HTTP, first hop off host, to HTTPS.
- Destructure the redirect chains from `requests.responses`.
- Clarify that the HTTPS chain is only a display fallback for `destination` when there is no HTTP response; pass/fail is decided by the HTTP chain alone.

### Motivation

Prevent a preloaded redirect chain from masking a site that still serves its final destination over plain HTTP. A non-redirecting site on the HSTS preload list was credited with `RedirectionAllRedirectsPreloaded` instead of failing with `RedirectionMissing`, and a fully preloaded chain ending on `http:` passed as well.

The first-hop checks (`RedirectionNotToHttpsOnInitialRedirection`, `RedirectionOffHostFromHttp`) stay behind the preload check on purpose: they exist so the HSTS header can take effect, which preloading already guarantees.

### Additional details

Split out of #495, which fixes the `retriever` so that `httpsRedirects` actually comes from the HTTPS session. The two PRs touch disjoint files and can be merged in either order.

Side effect: an empty HTTP redirect chain alongside an HTTP response (which the retriever never produces) now yields `RedirectionNotToHttps` instead of passing via a vacuous `every()`.

### Related issues and pull requests

Relates to #495.
