### PR TITLE
build(npm): make installs forward-compatible with npm 12

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,9 +48,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Install npm@>=11.8.0
-        run: npm install -g npm@>=11.8.0
-
       - name: Install
         run: npm ci
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,8 +48,8 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: Install npm@^11.8.0
-        run: npm install -g npm@^11.8.0
+      - name: Install npm@>=11.8.0
+        run: npm install -g npm@>=11.8.0
 
       - name: Install
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,8 +135,7 @@ jobs:
         shell: bash
         run: |
           TARBALL=$(ls mdn-mdn-http-observatory-*.tgz)
-          # npm >= 12 blocks install scripts by default, and a global install has
-          # no root package.json to read an `allowScripts` allowlist from.
+          # Global installs cannot read the `allowScripts` allowlist.
           npm install -g --dangerously-allow-all-scripts "$TARBALL"
 
       - name: Test --help output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,9 @@ jobs:
         shell: bash
         run: |
           TARBALL=$(ls mdn-mdn-http-observatory-*.tgz)
-          npm install -g "$TARBALL"
+          # npm >= 12 blocks install scripts by default, and a global install has
+          # no root package.json to read an `allowScripts` allowlist from.
+          npm install -g --dangerously-allow-all-scripts "$TARBALL"
 
       - name: Test --help output
         shell: bash

--- a/package.json
+++ b/package.json
@@ -92,5 +92,12 @@
   },
   "optionalDependencies": {
     "pg-native": "^3.7.0"
+  },
+  "allowScripts": {
+    "fsevents": true,
+    "lefthook": true,
+    "libpq": true,
+    "node_extra_ca_certs_mozilla_bundle": true,
+    "unrs-resolver": true
   }
 }


### PR DESCRIPTION
### Description

- Add an `allowScripts` allowlist for the dependencies with install scripts.
- Drop the global npm install step in `npm-publish.yml`.
- Pass `--dangerously-allow-all-scripts` to the global tarball install in `test.yml`.

### Motivation

npm 12 blocks dependency install scripts unless they are allowlisted, and `npm ci` still exits 0 either way, so the breakage surfaces as a confusing runtime error rather than a failed install. Here `libpq` and `node_extra_ca_certs_mozilla_bundle` never build, and the `test-cli` scan fails because the HSTS preload and TLD lists are never downloaded.

### Additional details

- Entries are name-only (`--no-allow-scripts-pin`), so Dependabot bumps need no re-approval commits, at the cost of trusting future versions of the listed packages.
- `npm@^11.8.0` was meant as a floor for provenance support (#491), not an upper bound, but it refuses to install npm 12. Node v24.19.0 from `.nvmrc` already ships npm v11.17.0, so the step is no longer needed.
- `test-cli` installs the packed tarball globally, and a global install has no root `package.json` to read an allowlist from. A name-based `--allow-scripts=@mdn/mdn-http-observatory` matches a registry install but not a local tarball (only the absolute tarball path does, which is not portable across the Linux/macOS/Windows matrix), so `--dangerously-allow-all-scripts` is the workable option for a tarball we packed one job earlier.
- Verified: `npm ci --strict-allow-scripts` and the global tarball install both pass on npm 12.0.2.

### Related issues and pull requests

Part of mdn/fred#1868.